### PR TITLE
Refactor CLI names and package scoping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ go.work.sum
 .vscode/
 
 # built binary
-/gevals
-/eval
+/agent
+/runner

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-CLI_BINARY_NAME = gevals
+AGENT_BINARY_NAME = agent
+RUNNER_BINARY_NAME = runner
 
 .PHONY: clean
 clean:
-	rm -f $(CLI_BINARY_NAME)
+	rm -f $(AGENT_BINARY_NAME) $(RUNNER_BINARY_NAME)
+
+.PHONY: build-agent
+build-agent: clean
+	go build -o $(AGENT_BINARY_NAME) ./cmd/agent
+
+.PHONY: build-runner
+build-runner: clean
+	go build -o $(RUNNER_BINARY_NAME) ./cmd/runner
 
 .PHONY: build
-build: clean
-	go build -o $(CLI_BINARY_NAME) ./cmd/gevals
+build: build-agent build-runner
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/genmcp/gevals/pkg/agent/core"
 	"log"
 	"os"
 	"strings"
 
-	"github.com/genmcp/gevals/pkg/agent"
 	"github.com/spf13/cobra"
 )
 
@@ -21,13 +21,13 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "gevals-cli",
+	Use:   "agent-cli",
 	Short: "A CLI tool that connects to an MCP server and runs an OpenAI compliant agent",
-	Long: `gevals-cli is a command-line interface that connects to a Model Context Protocol (MCP)
+	Long: `agent-cli is a command-line interface that connects to a Model Context Protocol (MCP)
 server and uses OpenAI compliant API to run an intelligent agent. The agent can interact with
 tools provided by the MCP server to accomplish tasks.`,
-	Example: `  gevals-cli --mcp-url http://localhost:3000 --prompt "What files are in the current directory?"
-  gevals-cli --mcp-url http://localhost:3000 --prompt "Read the README file" --model-name gpt-4o`,
+	Example: `  agent-cli --mcp-url http://localhost:3000 --prompt "What files are in the current directory?"
+  agent-cli --mcp-url http://localhost:3000 --prompt "Read the README file" --model-name gpt-4o`,
 	RunE: runAgent,
 }
 
@@ -63,7 +63,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 
 	// Create the AI agent
 	fmt.Printf("Creating AI agent with modelName: %s\n", modelName)
-	agentInstance, err := agent.NewAIAgent(modelBaseURL, modelKey, modelName, systemPrompt)
+	agentInstance, err := core.NewAIAgent(modelBaseURL, modelKey, modelName, systemPrompt)
 	if err != nil {
 		return fmt.Errorf("failed to create AI agent: %w", err)
 	}

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -14,12 +14,12 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "eval",
+	Use:   "runner",
 	Short: "Evaluate agent CLI performance on tasks",
-	Long: `eval is a framework for evaluating how well agent CLI binaries perform on defined tasks.
+	Long: `runner is a framework for evaluating how well agent CLI binaries perform on defined tasks.
 Tasks include prompts, optional setup/verifier/cleanup scripts, and expected output patterns.`,
-	Example: `  eval --agent "my-agent '{{.Prompt}}'" --task task.yaml
-  eval --agent "agent-cli --prompt '{{.Prompt}}'" --task tasks/create-pod.yaml`,
+	Example: `  runner --agent "my-agent '{{.Prompt}}'" --task task.yaml
+  runner --agent "agent-cli --prompt '{{.Prompt}}'" --task tasks/create-pod.yaml`,
 	RunE: runEvaluation,
 }
 
@@ -30,7 +30,7 @@ func init() {
 
 	// Mark required flags
 	rootCmd.MarkFlagRequired("agent")
-	rootCmd.MarkFlagRequired("task")
+	//	rootCmd.MarkFlagRequired("task")
 }
 
 func runEvaluation(cmd *cobra.Command, args []string) error {

--- a/pkg/agent/core/agent.go
+++ b/pkg/agent/core/agent.go
@@ -1,11 +1,11 @@
-package agent
+package core
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/genmcp/gevals/pkg/agent/mcp"
 
-	"github.com/genmcp/gevals/pkg/mcp"
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/option"
 	"github.com/openai/openai-go/v2/shared"

--- a/pkg/agent/mcp/mcp.go
+++ b/pkg/agent/mcp/mcp.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/shared"
-	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // Client wraps MCP SDK functionality for tool calling
@@ -20,7 +20,7 @@ type Client struct {
 func NewClient(ctx context.Context, serverURL string) (*Client, error) {
 	// Create MCP client with implementation info
 	client := mcpsdk.NewClient(&mcpsdk.Implementation{
-		Name:    "gevals-agent",
+		Name:    "agent-agent",
 		Version: "1.0.0",
 	}, nil)
 


### PR DESCRIPTION
* defining a clear path for `runner` (of tasks, with "agents"), as well as the `agent` itself
* moved mcp client bits down to `pkg/agent`
* updated Makefile and gitignore 